### PR TITLE
[TAS-213] 写真削除機能の追加 (WIP)

### DIFF
--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -64,4 +64,12 @@ class PhotoController {
       storeId,
     );
   }
+
+  Future<void> deletePhoto(
+    String userId,
+    String photoId,
+    String photoUrl,
+  ) async {
+    await _photoRepository.deletePhoto(userId, photoId, photoUrl);
+  }
 }

--- a/lib/features/photo/photo_detail/photo_detail_controller.dart
+++ b/lib/features/photo/photo_detail/photo_detail_controller.dart
@@ -1,0 +1,18 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final photoDetailControllerProvider =
+    NotifierProvider<PhotoDetailController, bool>(() {
+  return PhotoDetailController();
+});
+
+class PhotoDetailController extends Notifier<bool> {
+  @override
+  bool build() {
+    return false;
+  }
+
+  /// 編集モードを切り替える
+  void toggleEditing() {
+    state = !state;
+  }
+}

--- a/lib/features/photo/photo_detail/widgets/photo_detail_card.dart
+++ b/lib/features/photo/photo_detail/widgets/photo_detail_card.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import 'card_back.dart';
 import 'card_front.dart';
 
-class PhotoDetailCard extends StatefulWidget {
+class PhotoDetailCard extends StatelessWidget {
   const PhotoDetailCard({
     super.key,
+    required this.isEditing,
+    required this.onDelete,
     required this.onSelected,
     required this.userId,
     required this.photoId,
@@ -21,6 +23,8 @@ class PhotoDetailCard extends StatefulWidget {
     required this.storeOpeningHours,
   });
 
+  final bool isEditing;
+  final VoidCallback onDelete;
   final String userId;
   final String photoId;
   final List<String> areaStoreIds;
@@ -36,39 +40,17 @@ class PhotoDetailCard extends StatefulWidget {
   final void Function() onSelected;
 
   @override
-  State<PhotoDetailCard> createState() => _PhotoDetailCardState();
-}
-
-class _PhotoDetailCardState extends State<PhotoDetailCard> {
-  String get userId => widget.userId;
-
-  String get photoId => widget.photoId;
-
-  List<String> get areaStoreIds => widget.areaStoreIds;
-
-  String get storeName => widget.storeName;
-
-  DateTime get dateTime => widget.dateTime;
-
-  String get formattedDate =>
-      '${dateTime.year}/${dateTime.month}/${dateTime.day}';
-
-  String get address => widget.address;
-
-  String get photoUrl => widget.photoUrl;
-
-  String get storeUrl => widget.storeUrl;
-
-  List<String> get storeImageUrls => widget.storeImageUrls;
-
-  Map<String, String> get storeOpeningHours => widget.storeOpeningHours;
-
-  bool get showCardBack => widget.showCardBack;
-
-  @override
   Widget build(BuildContext context) {
-    return showCardBack
-        ? FlipCard(
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: isEditing ? Colors.blue : Colors.transparent,
+          width: 2,
+        ),
+      ),
+      child: Stack(
+        children: [
+          FlipCard(
             fill: Fill.fillBack,
             front: CardFront(
               photoUrl: photoUrl,
@@ -78,7 +60,7 @@ class _PhotoDetailCardState extends State<PhotoDetailCard> {
               showCardBack: showCardBack,
             ),
             back: CardBack(
-              onSelected: widget.onSelected,
+              onSelected: onSelected,
               userId: userId,
               photoId: photoId,
               areaStoreIds: areaStoreIds,
@@ -89,13 +71,24 @@ class _PhotoDetailCardState extends State<PhotoDetailCard> {
               storeUrl: storeUrl,
               storeOpeningHours: storeOpeningHours,
             ),
-          )
-        : CardFront(
-            photoUrl: photoUrl,
-            storeName: storeName,
-            dateTime: dateTime,
-            address: address,
-            showCardBack: showCardBack,
-          );
+          ),
+
+          /// 編集モード時に暗くしてゴミ箱アイコンを表示
+          if (isEditing)
+            Positioned.fill(
+              child: Center(
+                child: IconButton(
+                  icon: const Icon(
+                    Icons.delete,
+                    size: 50,
+                    color: Colors.white,
+                  ),
+                  onPressed: onDelete, // 削除処理を呼び出す
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -237,6 +238,29 @@ class PhotoRepository {
       debugPrint('StoreId updated successfully for photoId: $photoId');
     } else {
       logger.e('Error Photo with id: $photoId does not exist.');
+    }
+  }
+
+  /// FirestoreとGCSから写真を削除する
+  Future<void> deletePhoto(
+    String userId,
+    String photoId,
+    String photoUrl,
+  ) async {
+    try {
+      // Firestoreから該当の写真ドキュメントを削除
+      final photoDoc = photosRef(userId: userId).doc(photoId);
+      await photoDoc.delete();
+      debugPrint('Firestore document deleted for photoId: $photoId');
+
+      // GCSから該当の写真ファイルを削除
+      final storageRef = FirebaseStorage.instance.refFromURL(photoUrl);
+      await storageRef.delete();
+      debugPrint('Photo deleted from storage for photoUrl: $photoUrl');
+    } on Exception catch (e) {
+      // エラーハンドリング
+      logger.e('Failed to delete photo: $e');
+      throw Exception('Failed to delete photo: $e');
     }
   }
 }


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/e089fa075c0344e1a1fa5f31442ac716
## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 写真詳細ページのFirestoreの削除関数および、UIのコードを実装。（テスト未実施）

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [ ] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [ ] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->

このプルリクは、10/17のMTGで議題に上がっていたphoto_detail_page.dartのFutureProvider化
およびコンポーネント化のプルリクです。