### PR TITLE
[TAS-213] 写真詳細ページの改善：写真削除後の自動リフレッシュを追加

### DIFF
--- a/lib/features/photo/photo_detail/photo_detail_page.dart
+++ b/lib/features/photo/photo_detail/photo_detail_page.dart
@@ -180,8 +180,10 @@ class PhotoDetailPage extends HookConsumerWidget {
                                         photoUrl,
                                       );
                                       if (context.mounted) {
-                                        // 削除後にホームページに遷移
-                                        context.goNamed(HomePage.routeName);
+                                        ref.invalidate(photoControllerProvider);
+                                        context.pushReplacementNamed(
+                                          HomePage.routeName,
+                                        );
                                       }
                                     },
                                     hasCancelButton: true,

--- a/lib/features/photo/photo_detail/photo_detail_page.dart
+++ b/lib/features/photo/photo_detail/photo_detail_page.dart
@@ -180,7 +180,6 @@ class PhotoDetailPage extends HookConsumerWidget {
                                         photoUrl,
                                       );
                                       if (context.mounted) {
-                                        ref.invalidate(photoControllerProvider);
                                         context.pushReplacementNamed(
                                           HomePage.routeName,
                                         );


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/e089fa075c0344e1a1fa5f31442ac716

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
 - `lib/features/photo/photo_detail/photo_detail_page.dart`において、削除後の処理を以下のように修正しました。
  - `ref.invalidate(photoControllerProvider)`でプロバイダーのキャッシュを無効化。
  - `context.goNamed(HomePage.routeName)`から、`context.pushReplacementNamed(HomePage.routeName)`に変更し、画面遷移後に最新の状態が反映されるように修正。


## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
<div align="center">
  <table>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/b7cc2901-5d3d-4f16-816c-d9054ca28afe" width="200" /></td>
      <td><img src="https://github.com/user-attachments/assets/bd3dd61b-649a-4d4e-aa56-f0c30448043e" width="200" /></td>
      <td><img src="https://github.com/user-attachments/assets/7dcff3f5-ae95-4659-a8aa-07a02df7bf04" width="200" /></td>
    </tr>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/86fcbbdb-10c3-4667-9fe8-2766d82922f6" width="200" /></td>
      <td><img src="https://github.com/user-attachments/assets/e9a36eee-0c94-49a8-9dc8-9eda83ee5b7c" width="200" /></td>
    </tr>
  </table>
</div>

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
- `pushReplacementNamed`を使用することで、削除後の画面スタックが置き換わり、リフレッシュが正しく行われることを確認しました。
- UIの動作が改善されたか、レビューの際に確認をお願いします。