### PR TITLE
[TAS-231][TAS-238] WIP: ギャラリー画面の写真をローカル写真に置き換え、表示速度と画質を改善

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -16,6 +16,9 @@ class Photos extends Table {
   /// 写真のパス
   TextColumn get path => text()();
 
+  /// FirestoreのドキュメントID
+  TextColumn get firestoreDocumentId => text().nullable()();
+
   /// 横サイズ
   IntColumn get width => integer().withDefault(const Constant(0))();
 
@@ -72,6 +75,10 @@ class AppDatabase extends _$AppDatabase {
           await m.addColumn(photos, photos.height);
           await m.addColumn(photos, photos.latitude);
           await m.addColumn(photos, photos.longitude);
+        }
+
+        if (from < 3) {
+          await m.addColumn(photos, photos.firestoreDocumentId);
         }
       },
     );

--- a/lib/core/local_photo_repository.dart
+++ b/lib/core/local_photo_repository.dart
@@ -94,4 +94,21 @@ class LocalPhotoRepository {
       await db.into(db.photoDetails).insert(lastPhotoModel);
     }
   }
+
+  /// Firestore ID とローカル画像パスをローカルDBに保存
+  Future<void> savePhotoWithFirestoreId({
+    required String localImagePath,
+    required String firestoreDocumentId,
+  }) async {
+    final photoModel = PhotosCompanion(
+      id: Value(firestoreDocumentId),
+      path: Value(localImagePath),
+      firestoreDocumentId: Value(firestoreDocumentId),
+    );
+
+    await db.into(db.photos).insert(
+          photoModel,
+          mode: InsertMode.insertOrIgnore,
+        );
+  }
 }

--- a/lib/core/local_photo_repository.dart
+++ b/lib/core/local_photo_repository.dart
@@ -96,7 +96,7 @@ class LocalPhotoRepository {
   }
 
   /// Firestore ID とローカル画像パスをローカルDBに保存
-  Future<void> savePhotoWithFirestoreId({
+  Future<String> savePhotoWithFirestoreId({
     required String localImagePath,
     required String firestoreDocumentId,
   }) async {
@@ -110,5 +110,7 @@ class LocalPhotoRepository {
           photoModel,
           mode: InsertMode.insertOrIgnore,
         );
+
+    return firestoreDocumentId;
   }
 }

--- a/lib/features/photo/gallery/gallery_page.dart
+++ b/lib/features/photo/gallery/gallery_page.dart
@@ -20,7 +20,7 @@ class HomePage extends HookConsumerWidget {
 
   Future<void> _downloadPhotos(
     WidgetRef ref,
-    ValueNotifier<List<Photo>?> photoUrls,
+    ValueNotifier<List<RemotePhoto>?> photoUrls,
   ) async {
     final userId = ref.watch(userIdProvider);
 
@@ -39,7 +39,7 @@ class HomePage extends HookConsumerWidget {
     WidgetRef ref,
     BuildContext context,
     ValueNotifier<bool> isReady,
-    ValueNotifier<List<Photo>?> photoUrls,
+    ValueNotifier<List<RemotePhoto>?> photoUrls,
   ) async {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       final isSignedIn = ref.watch(userIdProvider) != null;
@@ -64,7 +64,7 @@ class HomePage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isReady = useState(false);
-    final photoUrls = useState<List<Photo>?>(null);
+    final photoUrls = useState<List<RemotePhoto>?>(null);
 
     final tabController = useTabController(initialLength: 6);
 
@@ -118,13 +118,13 @@ class HomePage extends HookConsumerWidget {
   Widget _buildPhotoGrid(
     BuildContext context,
     String category,
-    List<Photo>? photoUrls,
+    List<RemotePhoto>? photoUrls,
   ) {
     if (photoUrls == null) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    List<Photo> filteredPhotos;
+    List<RemotePhoto> filteredPhotos;
     if (category == 'すべて') {
       filteredPhotos = photoUrls;
     } else {

--- a/lib/features/photo/photo.dart
+++ b/lib/features/photo/photo.dart
@@ -27,6 +27,12 @@ class Photo with _$Photo {
     /// FirebaseStorageに保存された写真のURL
     @Default('') String url,
 
+    /// ローカルストレージに保存された画像のパス
+    @Default('') String localImagePath,
+
+    /// Firestoreに保存されたドキュメントのID
+    @Default('') String firestoreDocumentId,
+
     /// geminiで推論した写真のカテゴリ
     /// ここをstringではなくてenumに変換して格納しておくと、
     /// Flutter上では型安全に扱えて想定外の実行時エラーが防げるため修正したい

--- a/lib/features/photo/photo.dart
+++ b/lib/features/photo/photo.dart
@@ -6,8 +6,8 @@ part 'photo.freezed.dart';
 part 'photo.g.dart';
 
 @freezed
-class Photo with _$Photo {
-  const factory Photo({
+class RemotePhoto with _$RemotePhoto {
+  const factory RemotePhoto({
     /// firestore上のドキュメントID
     @Default('') String id,
 
@@ -46,9 +46,10 @@ class Photo with _$Photo {
     @Default(UnionTimestamp.serverTimestamp())
     UnionTimestamp shotAt,
     @Default('') String storeId,
-  }) = _Photo;
+  }) = _RemotePhoto;
 
-  const Photo._();
+  const RemotePhoto._();
 
-  factory Photo.fromJson(Map<String, dynamic> json) => _$PhotoFromJson(json);
+  factory RemotePhoto.fromJson(Map<String, dynamic> json) =>
+      _$RemotePhotoFromJson(json);
 }

--- a/lib/features/photo/photo.freezed.dart
+++ b/lib/features/photo/photo.freezed.dart
@@ -37,6 +37,12 @@ mixin _$Photo {
   /// FirebaseStorageに保存された写真のURL
   String get url => throw _privateConstructorUsedError;
 
+  /// ローカルストレージに保存された画像のパス
+  String get localImagePath => throw _privateConstructorUsedError;
+
+  /// Firestoreに保存されたドキュメントのID
+  String get firestoreDocumentId => throw _privateConstructorUsedError;
+
   /// geminiで推論した写真のカテゴリ
   /// ここをstringではなくてenumに変換して格納しておくと、
   /// Flutter上では型安全に扱えて想定外の実行時エラーが防げるため修正したい
@@ -66,6 +72,8 @@ abstract class $PhotoCopyWith<$Res> {
       @serverTimestampConverter UnionTimestamp updatedAt,
       List<String> areaStoreIds,
       String url,
+      String localImagePath,
+      String firestoreDocumentId,
       String category,
       String userId,
       @timestampConverter UnionTimestamp shotAt,
@@ -94,6 +102,8 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
     Object? updatedAt = null,
     Object? areaStoreIds = null,
     Object? url = null,
+    Object? localImagePath = null,
+    Object? firestoreDocumentId = null,
     Object? category = null,
     Object? userId = null,
     Object? shotAt = null,
@@ -119,6 +129,14 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      localImagePath: null == localImagePath
+          ? _value.localImagePath
+          : localImagePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      firestoreDocumentId: null == firestoreDocumentId
+          ? _value.firestoreDocumentId
+          : firestoreDocumentId // ignore: cast_nullable_to_non_nullable
               as String,
       category: null == category
           ? _value.category
@@ -177,6 +195,8 @@ abstract class _$$PhotoImplCopyWith<$Res> implements $PhotoCopyWith<$Res> {
       @serverTimestampConverter UnionTimestamp updatedAt,
       List<String> areaStoreIds,
       String url,
+      String localImagePath,
+      String firestoreDocumentId,
       String category,
       String userId,
       @timestampConverter UnionTimestamp shotAt,
@@ -206,6 +226,8 @@ class __$$PhotoImplCopyWithImpl<$Res>
     Object? updatedAt = null,
     Object? areaStoreIds = null,
     Object? url = null,
+    Object? localImagePath = null,
+    Object? firestoreDocumentId = null,
     Object? category = null,
     Object? userId = null,
     Object? shotAt = null,
@@ -231,6 +253,14 @@ class __$$PhotoImplCopyWithImpl<$Res>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      localImagePath: null == localImagePath
+          ? _value.localImagePath
+          : localImagePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      firestoreDocumentId: null == firestoreDocumentId
+          ? _value.firestoreDocumentId
+          : firestoreDocumentId // ignore: cast_nullable_to_non_nullable
               as String,
       category: null == category
           ? _value.category
@@ -263,6 +293,8 @@ class _$PhotoImpl extends _Photo {
       this.updatedAt = const UnionTimestamp.serverTimestamp(),
       final List<String> areaStoreIds = const <String>[],
       this.url = '',
+      this.localImagePath = '',
+      this.firestoreDocumentId = '',
       this.category = '',
       this.userId = '',
       @timestampConverter this.shotAt = const UnionTimestamp.serverTimestamp(),
@@ -307,6 +339,16 @@ class _$PhotoImpl extends _Photo {
   @JsonKey()
   final String url;
 
+  /// ローカルストレージに保存された画像のパス
+  @override
+  @JsonKey()
+  final String localImagePath;
+
+  /// Firestoreに保存されたドキュメントのID
+  @override
+  @JsonKey()
+  final String firestoreDocumentId;
+
   /// geminiで推論した写真のカテゴリ
   /// ここをstringではなくてenumに変換して格納しておくと、
   /// Flutter上では型安全に扱えて想定外の実行時エラーが防げるため修正したい
@@ -330,7 +372,7 @@ class _$PhotoImpl extends _Photo {
 
   @override
   String toString() {
-    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, areaStoreIds: $areaStoreIds, url: $url, category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
+    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, areaStoreIds: $areaStoreIds, url: $url, localImagePath: $localImagePath, firestoreDocumentId: $firestoreDocumentId, category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
   }
 
   @override
@@ -346,6 +388,10 @@ class _$PhotoImpl extends _Photo {
             const DeepCollectionEquality()
                 .equals(other._areaStoreIds, _areaStoreIds) &&
             (identical(other.url, url) || other.url == url) &&
+            (identical(other.localImagePath, localImagePath) ||
+                other.localImagePath == localImagePath) &&
+            (identical(other.firestoreDocumentId, firestoreDocumentId) ||
+                other.firestoreDocumentId == firestoreDocumentId) &&
             (identical(other.category, category) ||
                 other.category == category) &&
             (identical(other.userId, userId) || other.userId == userId) &&
@@ -362,6 +408,8 @@ class _$PhotoImpl extends _Photo {
       updatedAt,
       const DeepCollectionEquality().hash(_areaStoreIds),
       url,
+      localImagePath,
+      firestoreDocumentId,
       category,
       userId,
       shotAt,
@@ -388,6 +436,8 @@ abstract class _Photo extends Photo {
       @serverTimestampConverter final UnionTimestamp updatedAt,
       final List<String> areaStoreIds,
       final String url,
+      final String localImagePath,
+      final String firestoreDocumentId,
       final String category,
       final String userId,
       @timestampConverter final UnionTimestamp shotAt,
@@ -418,6 +468,14 @@ abstract class _Photo extends Photo {
 
   /// FirebaseStorageに保存された写真のURL
   String get url;
+  @override
+
+  /// ローカルストレージに保存された画像のパス
+  String get localImagePath;
+  @override
+
+  /// Firestoreに保存されたドキュメントのID
+  String get firestoreDocumentId;
   @override
 
   /// geminiで推論した写真のカテゴリ

--- a/lib/features/photo/photo.freezed.dart
+++ b/lib/features/photo/photo.freezed.dart
@@ -14,12 +14,12 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
-Photo _$PhotoFromJson(Map<String, dynamic> json) {
-  return _Photo.fromJson(json);
+RemotePhoto _$RemotePhotoFromJson(Map<String, dynamic> json) {
+  return _RemotePhoto.fromJson(json);
 }
 
 /// @nodoc
-mixin _$Photo {
+mixin _$RemotePhoto {
   /// firestore上のドキュメントID
   String get id => throw _privateConstructorUsedError;
 
@@ -58,13 +58,15 @@ mixin _$Photo {
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $PhotoCopyWith<Photo> get copyWith => throw _privateConstructorUsedError;
+  $RemotePhotoCopyWith<RemotePhoto> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $PhotoCopyWith<$Res> {
-  factory $PhotoCopyWith(Photo value, $Res Function(Photo) then) =
-      _$PhotoCopyWithImpl<$Res, Photo>;
+abstract class $RemotePhotoCopyWith<$Res> {
+  factory $RemotePhotoCopyWith(
+          RemotePhoto value, $Res Function(RemotePhoto) then) =
+      _$RemotePhotoCopyWithImpl<$Res, RemotePhoto>;
   @useResult
   $Res call(
       {String id,
@@ -85,9 +87,9 @@ abstract class $PhotoCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
-    implements $PhotoCopyWith<$Res> {
-  _$PhotoCopyWithImpl(this._value, this._then);
+class _$RemotePhotoCopyWithImpl<$Res, $Val extends RemotePhoto>
+    implements $RemotePhotoCopyWith<$Res> {
+  _$RemotePhotoCopyWithImpl(this._value, this._then);
 
   // ignore: unused_field
   final $Val _value;
@@ -183,10 +185,11 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
 }
 
 /// @nodoc
-abstract class _$$PhotoImplCopyWith<$Res> implements $PhotoCopyWith<$Res> {
-  factory _$$PhotoImplCopyWith(
-          _$PhotoImpl value, $Res Function(_$PhotoImpl) then) =
-      __$$PhotoImplCopyWithImpl<$Res>;
+abstract class _$$RemotePhotoImplCopyWith<$Res>
+    implements $RemotePhotoCopyWith<$Res> {
+  factory _$$RemotePhotoImplCopyWith(
+          _$RemotePhotoImpl value, $Res Function(_$RemotePhotoImpl) then) =
+      __$$RemotePhotoImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -211,11 +214,11 @@ abstract class _$$PhotoImplCopyWith<$Res> implements $PhotoCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$PhotoImplCopyWithImpl<$Res>
-    extends _$PhotoCopyWithImpl<$Res, _$PhotoImpl>
-    implements _$$PhotoImplCopyWith<$Res> {
-  __$$PhotoImplCopyWithImpl(
-      _$PhotoImpl _value, $Res Function(_$PhotoImpl) _then)
+class __$$RemotePhotoImplCopyWithImpl<$Res>
+    extends _$RemotePhotoCopyWithImpl<$Res, _$RemotePhotoImpl>
+    implements _$$RemotePhotoImplCopyWith<$Res> {
+  __$$RemotePhotoImplCopyWithImpl(
+      _$RemotePhotoImpl _value, $Res Function(_$RemotePhotoImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -233,7 +236,7 @@ class __$$PhotoImplCopyWithImpl<$Res>
     Object? shotAt = null,
     Object? storeId = null,
   }) {
-    return _then(_$PhotoImpl(
+    return _then(_$RemotePhotoImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -284,8 +287,8 @@ class __$$PhotoImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$PhotoImpl extends _Photo {
-  const _$PhotoImpl(
+class _$RemotePhotoImpl extends _RemotePhoto {
+  const _$RemotePhotoImpl(
       {this.id = '',
       @timestampConverter
       this.createdAt = const UnionTimestamp.serverTimestamp(),
@@ -302,8 +305,8 @@ class _$PhotoImpl extends _Photo {
       : _areaStoreIds = areaStoreIds,
         super._();
 
-  factory _$PhotoImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PhotoImplFromJson(json);
+  factory _$RemotePhotoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemotePhotoImplFromJson(json);
 
   /// firestore上のドキュメントID
   @override
@@ -372,14 +375,14 @@ class _$PhotoImpl extends _Photo {
 
   @override
   String toString() {
-    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, areaStoreIds: $areaStoreIds, url: $url, localImagePath: $localImagePath, firestoreDocumentId: $firestoreDocumentId, category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
+    return 'RemotePhoto(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, areaStoreIds: $areaStoreIds, url: $url, localImagePath: $localImagePath, firestoreDocumentId: $firestoreDocumentId, category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PhotoImpl &&
+            other is _$RemotePhotoImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
@@ -418,19 +421,19 @@ class _$PhotoImpl extends _Photo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PhotoImplCopyWith<_$PhotoImpl> get copyWith =>
-      __$$PhotoImplCopyWithImpl<_$PhotoImpl>(this, _$identity);
+  _$$RemotePhotoImplCopyWith<_$RemotePhotoImpl> get copyWith =>
+      __$$RemotePhotoImplCopyWithImpl<_$RemotePhotoImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PhotoImplToJson(
+    return _$$RemotePhotoImplToJson(
       this,
     );
   }
 }
 
-abstract class _Photo extends Photo {
-  const factory _Photo(
+abstract class _RemotePhoto extends RemotePhoto {
+  const factory _RemotePhoto(
       {final String id,
       @timestampConverter final UnionTimestamp createdAt,
       @serverTimestampConverter final UnionTimestamp updatedAt,
@@ -441,10 +444,11 @@ abstract class _Photo extends Photo {
       final String category,
       final String userId,
       @timestampConverter final UnionTimestamp shotAt,
-      final String storeId}) = _$PhotoImpl;
-  const _Photo._() : super._();
+      final String storeId}) = _$RemotePhotoImpl;
+  const _RemotePhoto._() : super._();
 
-  factory _Photo.fromJson(Map<String, dynamic> json) = _$PhotoImpl.fromJson;
+  factory _RemotePhoto.fromJson(Map<String, dynamic> json) =
+      _$RemotePhotoImpl.fromJson;
 
   @override
 
@@ -495,6 +499,6 @@ abstract class _Photo extends Photo {
   String get storeId;
   @override
   @JsonKey(ignore: true)
-  _$$PhotoImplCopyWith<_$PhotoImpl> get copyWith =>
+  _$$RemotePhotoImplCopyWith<_$RemotePhotoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/features/photo/photo.g.dart
+++ b/lib/features/photo/photo.g.dart
@@ -19,6 +19,8 @@ _$PhotoImpl _$$PhotoImplFromJson(Map<String, dynamic> json) => _$PhotoImpl(
               .toList() ??
           const <String>[],
       url: json['url'] as String? ?? '',
+      localImagePath: json['localImagePath'] as String? ?? '',
+      firestoreDocumentId: json['firestoreDocumentId'] as String? ?? '',
       category: json['category'] as String? ?? '',
       userId: json['userId'] as String? ?? '',
       shotAt: json['shotAt'] == null
@@ -34,6 +36,8 @@ Map<String, dynamic> _$$PhotoImplToJson(_$PhotoImpl instance) =>
       'updatedAt': serverTimestampConverter.toJson(instance.updatedAt),
       'areaStoreIds': instance.areaStoreIds,
       'url': instance.url,
+      'localImagePath': instance.localImagePath,
+      'firestoreDocumentId': instance.firestoreDocumentId,
       'category': instance.category,
       'userId': instance.userId,
       'shotAt': timestampConverter.toJson(instance.shotAt),

--- a/lib/features/photo/photo.g.dart
+++ b/lib/features/photo/photo.g.dart
@@ -6,7 +6,8 @@ part of 'photo.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PhotoImpl _$$PhotoImplFromJson(Map<String, dynamic> json) => _$PhotoImpl(
+_$RemotePhotoImpl _$$RemotePhotoImplFromJson(Map<String, dynamic> json) =>
+    _$RemotePhotoImpl(
       id: json['id'] as String? ?? '',
       createdAt: json['createdAt'] == null
           ? const UnionTimestamp.serverTimestamp()
@@ -29,7 +30,7 @@ _$PhotoImpl _$$PhotoImplFromJson(Map<String, dynamic> json) => _$PhotoImpl(
       storeId: json['storeId'] as String? ?? '',
     );
 
-Map<String, dynamic> _$$PhotoImplToJson(_$PhotoImpl instance) =>
+Map<String, dynamic> _$$RemotePhotoImplToJson(_$RemotePhotoImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'createdAt': timestampConverter.toJson(instance.createdAt),

--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -18,14 +18,14 @@ class PhotoController {
   PhotoRepository get _photoRepository => _ref.read(photoRepositoryProvider);
 
   /// 写真ダウンロード用メソッド
-  Future<List<Photo>> downloadPhotos({
+  Future<List<RemotePhoto>> downloadPhotos({
     required String userId,
   }) async {
     return _photoRepository.downloadPhotos(userId: userId);
   }
 
   // TODO(kim): Photo?の部分はあとで書き換える。
-  Future<Photo?> downloadPhoto({
+  Future<RemotePhoto?> downloadPhoto({
     required String userId,
     required String photoId,
   }) async {
@@ -42,7 +42,7 @@ class PhotoController {
     );
   }
 
-  Future<Photo?> getPhotoById({
+  Future<RemotePhoto?> getPhotoById({
     required String userId,
     required String photoId,
   }) async {

--- a/lib/features/photo/photo_detail/photo_detail_page.dart
+++ b/lib/features/photo/photo_detail/photo_detail_page.dart
@@ -34,7 +34,7 @@ class PhotoDetailPage extends HookConsumerWidget {
       viewportFraction: 0.9,
     );
 
-    final photo = useState<Future<Photo?>?>(null);
+    final photo = useState<Future<RemotePhoto?>?>(null);
 
     final userId = ref.watch(userIdProvider);
 
@@ -61,7 +61,7 @@ class PhotoDetailPage extends HookConsumerWidget {
       [],
     );
 
-    Future<Store?> fetchStore(Photo photo) async {
+    Future<Store?> fetchStore(RemotePhoto photo) async {
       final storeController = ref.read(storeControllerProvider);
       final userId = FirebaseAuth.instance.currentUser!.uid;
 

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -12,7 +12,6 @@ import 'package:http/http.dart' as http;
 import '../../core/flavor.dart';
 import '../../core/local_photo_repository.dart';
 import '../../core/logger.dart';
-import '../../core/timestamp_converter.dart';
 import 'photo.dart';
 
 /// [Photo]用コレクションのためのレファレンス
@@ -299,8 +298,6 @@ class PhotoRepository {
         userId: userId,
         localImagePath: localImagePath,
         url: downloadUrl,
-        createdAt: UnionTimestamp.serverTimestamp(),
-        updatedAt: UnionTimestamp.serverTimestamp(),
       );
 
       await photoDoc.set(photo);

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -14,21 +14,21 @@ import '../../core/local_photo_repository.dart';
 import '../../core/logger.dart';
 import 'photo.dart';
 
-/// [Photo]用コレクションのためのレファレンス
+/// [RemotePhoto]用コレクションのためのレファレンス
 ///
-/// [Photo]ドキュメントの操作にはこのレファレンスを経由すること。
+/// [RemotePhoto]ドキュメントの操作にはこのレファレンスを経由すること。
 /// fromFirestoreではドキュメントidを追加し、toFirestoreではドキュメントidを削除する。
 /// 常にtoFirestoreを経由するために、ドキュメント更新時には
 /// [DocumentReference.update]ではなく[DocumentReference.set]を用いる。
-CollectionReference<Photo> photosRef({required String userId}) {
+CollectionReference<RemotePhoto> photosRef({required String userId}) {
   return FirebaseFirestore.instance
       .collection('users')
       .doc(userId)
       .collection('photos')
-      .withConverter<Photo>(
+      .withConverter<RemotePhoto>(
     fromFirestore: (snapshot, _) {
       final data = snapshot.data()!;
-      return Photo.fromJson(<String, dynamic>{
+      return RemotePhoto.fromJson(<String, dynamic>{
         ...data,
         'id': snapshot.id,
       });
@@ -115,7 +115,7 @@ class PhotoRepository {
   }
 
   // TODO(firestore): データ作成後に動作確認 & 全件取得ではない取得方法検討
-  Future<List<Photo>> downloadPhotos({
+  Future<List<RemotePhoto>> downloadPhotos({
     required String userId,
   }) async {
     try {
@@ -136,13 +136,13 @@ class PhotoRepository {
             if (data != null) {
               (data as Map<String, dynamic>).addAll({'id': doc.id});
               // nullチェックを追加
-              return Photo.fromJson(data);
+              return RemotePhoto.fromJson(data);
             } else {
               return null;
             }
           })
           .where((photo) => photo != null)
-          .cast<Photo>()
+          .cast<RemotePhoto>()
           .toList();
     } on Exception catch (e) {
       logger.e('An error occurred: $e');
@@ -151,7 +151,7 @@ class PhotoRepository {
   }
 
   // TODO(kim): Photo?の部分はあとで書き換える。
-  Future<Photo?> downloadPhoto({
+  Future<RemotePhoto?> downloadPhoto({
     required String userId,
     required String photoId,
   }) async {
@@ -168,7 +168,7 @@ class PhotoRepository {
       if (data != null) {
         data.addAll({'id': photosSnap.id});
 
-        return Photo.fromJson(data);
+        return RemotePhoto.fromJson(data);
       } else {
         return null;
       }
@@ -178,7 +178,7 @@ class PhotoRepository {
     }
   }
 
-  Future<Photo?> getPhotoById({
+  Future<RemotePhoto?> getPhotoById({
     required String userId,
     required String photoId,
   }) async {
@@ -293,7 +293,7 @@ class PhotoRepository {
       final downloadUrl = await snapshot.ref.getDownloadURL();
 
       // Firestore に写真メタデータを保存
-      final photo = Photo(
+      final photo = RemotePhoto(
         id: photoId,
         userId: userId,
         localImagePath: localImagePath,


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/8d8793a9113b486cb69626c1c5f7432c
https://www.notion.so/masakisato/f3eaa6eb43d4424fa1e6e79096ad6cf4
## 対応したこと

- 実施中なので特になしです。

## 実現したいこと
### 目標
1. 画像の画質を向上させる。
2. 表示速度を改善する。
3. Firestore参照箇所をローカルDB参照に変更。

### 詳細な要件
- **ローカルDBでの画像パスとFirestore画像IDの紐付け**
- **ローカルDBの画像パス参照による効率的な画像表示**
- **カテゴリ情報のローカル参照への切り替え**

## 現状と課題
### 現状
- 画像の解像度が低い。
- ギャラリー画面の画像表示速度が遅い。
- FirestoreとローカルDB間のデータ統合が不十分。

### 課題
1. **画像画質の向上**: 
   - 圧縮・解凍ロジックやキャッシュの活用が必要。
2. **表示速度の改善**:
   - 遅延ロードや非同期処理の最適化が課題。
3. **Firestoreカテゴリ情報のローカル化**:
   - ローカルDBでのカテゴリ同期ロジックを設計・実装する必要がある。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- WIPなので受け入れ要件を満たすものができていません。

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
現在の挙動を以下に示します:
1. ギャラリー画面の画像表示に遅延が発生。
2. 低解像度の画像が表示される。

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] チームで解決すべきポイントを明確にするため、このドラフトプルリクエストを作成。
- [ ] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [ ] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
## 重点レビュー箇所
以下について、特にご意見をいただけると幸いです:
1. **画像画質向上の方法**:
   - 画像の圧縮・解凍ロジックや表示用キャッシュの適用方法。
2. **ローカル参照への切り替え設計**:
   - 効率的なデータ参照方法。
3. **FirestoreとローカルDBのカテゴリ情報同期**:
   - 現行のアプローチに対する改善案。