### PR TITLE
[hotfix]オンボーディング完了タイミングを変更

### DIFF
--- a/lib/features/auth/sign_in_page.dart
+++ b/lib/features/auth/sign_in_page.dart
@@ -7,7 +7,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 // TODO(kim): アナリティクスマージ後にコメントアウトを解除
 // import '../../core/analytics/analytics_service.dart';
 import '../../core/themes.dart';
-import '../onboarding/onboarding_controller.dart';
 import '../photo/swipe_photo/swipe_photo_page.dart';
 import 'auth_controller.dart';
 
@@ -112,9 +111,6 @@ class SignInPage extends HookConsumerWidget {
     try {
       isLoading.value = true;
       await signIn();
-      await ref
-          .read(isOnboardingCompletedNotifierProvider.notifier)
-          .update(isOnboardingCompleted: true);
       if (!context.mounted) {
         return;
       }

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -115,8 +115,10 @@ class OnboardingPage extends HookConsumerWidget {
                             //     .read(analyticsServiceProvider)
                             //     .sendEvent(name: 'complete_onboarding');
                             await ref
-                                .read(isOnboardingCompletedNotifierProvider
-                                    .notifier)
+                                .read(
+                                  isOnboardingCompletedNotifierProvider
+                                      .notifier,
+                                )
                                 .update(isOnboardingCompleted: true);
                             if (!context.mounted) {
                               return;

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import '../../core/build_context_extension.dart';
 import '../../core/widgets/custom_elevated_button.dart';
 import '../auth/sign_in_page.dart';
+import 'onboarding_controller.dart';
 
 /// オンボーディング用画面
 class OnboardingPage extends HookConsumerWidget {
@@ -102,9 +103,9 @@ class OnboardingPage extends HookConsumerWidget {
                     child: SizedBox(
                       height: 60,
                       child: CustomElevatedButton(
-                        onPressed: () {
+                        onPressed: () async {
                           if (!isLastPage) {
-                            pageController.nextPage(
+                            await pageController.nextPage(
                               duration: const Duration(milliseconds: 300),
                               curve: Curves.easeInOut,
                             );
@@ -113,6 +114,13 @@ class OnboardingPage extends HookConsumerWidget {
                             // ref
                             //     .read(analyticsServiceProvider)
                             //     .sendEvent(name: 'complete_onboarding');
+                            await ref
+                                .read(isOnboardingCompletedNotifierProvider
+                                    .notifier)
+                                .update(isOnboardingCompleted: true);
+                            if (!context.mounted) {
+                              return;
+                            }
                             context.go(SignInPage.routePath);
                           }
                         },


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 現状ではサインインページの上にオンボーディングページがStackされて表示されているため、変更。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

別途、以下の状況に対応：
オンボーディング完了してサインインページに飛んだが、そのタイミングでサインインせずに次回アプリ起動時にログインしていない

https://www.notion.so/masakisato/12-26-MTG-72d5aa70ceac4a8ba60f878241ebb82a?pvs=4#17aa4128da0f803b9a5cce542f40641e

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [ ] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
