### PR TITLE
[TAS-251] ダイアログの共通化

### DIFF
--- a/lib/core/themes.dart
+++ b/lib/core/themes.dart
@@ -266,4 +266,6 @@ abstract final class Themes {
     900: Color(0xFF180c00),
   });
   static const int _grayPrimaryValue = 0xFF90847c;
+
+  static const errorAlertColor = Color(0xffef3a45);
 }

--- a/lib/core/widgets/confirm_dialog.dart
+++ b/lib/core/widgets/confirm_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../themes.dart';
 
 /// 確認用のダイアログ
@@ -6,8 +7,8 @@ class ConfirmDialog extends StatelessWidget {
   const ConfirmDialog._({
     required this.contentString,
     required this.titleString,
-    this.negativeButtonString = 'キャンセル',
-    this.positiveButtonString = 'OK',
+    required this.negativeButtonString,
+    required this.positiveButtonString,
     required this.onConfirmed,
     required this.hasCancelButton,
     required this.shouldPopOnConfirmed,
@@ -42,8 +43,8 @@ class ConfirmDialog extends StatelessWidget {
     BuildContext context, {
     String? titleString,
     required String contentString,
-    String? negativeButtonString,
-    String? positiveButtonString,
+    String negativeButtonString = 'キャンセル',
+    String positiveButtonString = 'OK',
     required VoidCallback onConfirmed,
     bool hasCancelButton = false,
     bool shouldPopOnConfirmed = true,
@@ -56,8 +57,8 @@ class ConfirmDialog extends StatelessWidget {
         return ConfirmDialog._(
           titleString: titleString ?? '',
           contentString: contentString,
-          negativeButtonString: negativeButtonString ?? 'キャンセル',
-          positiveButtonString: positiveButtonString ?? 'OK',
+          negativeButtonString: negativeButtonString,
+          positiveButtonString: positiveButtonString,
           onConfirmed: onConfirmed,
           hasCancelButton: hasCancelButton,
           shouldPopOnConfirmed: shouldPopOnConfirmed,

--- a/lib/core/widgets/confirm_dialog.dart
+++ b/lib/core/widgets/confirm_dialog.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
-
-import '../../core/build_context_extension.dart';
+import '../themes.dart';
 
 /// 確認用のダイアログ
 class ConfirmDialog extends StatelessWidget {
   const ConfirmDialog._({
     required this.contentString,
     required this.titleString,
+    this.negativeButtonString = 'キャンセル',
+    this.positiveButtonString = 'OK',
     required this.onConfirmed,
     required this.hasCancelButton,
     required this.shouldPopOnConfirmed,
+    this.isDestructiveAction = false,
   });
 
   /// ダイアログのタイトル
@@ -17,6 +19,12 @@ class ConfirmDialog extends StatelessWidget {
 
   /// ダイアログの中身
   final String contentString;
+
+  /// 否定ボタンのテキスト
+  final String negativeButtonString;
+
+  /// 肯定ボタンテキスト
+  final String positiveButtonString;
 
   /// 「はい」ボタン押下後の挙動
   final VoidCallback onConfirmed;
@@ -27,24 +35,33 @@ class ConfirmDialog extends StatelessWidget {
   /// [onConfirmed]完了後にダイアログを閉じるかどうか
   final bool shouldPopOnConfirmed;
 
+  /// 破滅的な(もとに戻せない)アクションかどうか
+  final bool isDestructiveAction;
+
   static Future<void> show(
     BuildContext context, {
-    required String titleString,
+    String? titleString,
     required String contentString,
+    String? negativeButtonString,
+    String? positiveButtonString,
     required VoidCallback onConfirmed,
     bool hasCancelButton = false,
     bool shouldPopOnConfirmed = true,
+    bool isDestructiveAction = false,
   }) async {
     await showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (_) {
         return ConfirmDialog._(
-          titleString: titleString,
+          titleString: titleString ?? '',
           contentString: contentString,
+          negativeButtonString: negativeButtonString ?? 'キャンセル',
+          positiveButtonString: positiveButtonString ?? 'OK',
           onConfirmed: onConfirmed,
           hasCancelButton: hasCancelButton,
           shouldPopOnConfirmed: shouldPopOnConfirmed,
+          isDestructiveAction: isDestructiveAction,
         );
       },
     );
@@ -53,23 +70,26 @@ class ConfirmDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      titleTextStyle: Theme.of(context).textTheme.titleMedium,
+      contentTextStyle: Theme.of(context).textTheme.bodyLarge,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
       ),
       title: Center(
-        child: Text(
-          titleString,
-          style: context.textTheme.bodyMedium!.copyWith(
-            color: Colors.white,
-          ),
-        ),
+        child: Text(titleString),
       ),
       content: Text(contentString),
       actions: [
         if (hasCancelButton)
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: const Text('いいえ'),
+            child: Text(
+              negativeButtonString,
+              style: Theme.of(context)
+                  .textTheme
+                  .labelLarge
+                  ?.copyWith(color: Themes.gray),
+            ),
           ),
         TextButton(
           onPressed: () {
@@ -78,7 +98,14 @@ class ConfirmDialog extends StatelessWidget {
               Navigator.of(context).pop();
             }
           },
-          child: const Text('はい'),
+          child: Text(
+            positiveButtonString,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: isDestructiveAction
+                      ? Themes.errorAlertColor
+                      : Themes.mainOrange,
+                ),
+          ),
         ),
       ],
     );

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../core/themes.dart';
 import '../../core/widgets/confirm_dialog.dart';
 import '../../core/widgets/success_snack_bar.dart';
 import 'auth_controller.dart';
@@ -16,19 +17,22 @@ class MyPage extends ConsumerWidget {
     return Scaffold(
       // サインインのリスト部分の設定
       body: Container(
-        padding: const EdgeInsets.only(top: 50),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Column(
           children: [
             Expanded(
               child: ListView(
+                padding: const EdgeInsets.only(top: 160),
                 children: [
                   ListTile(
                     onTap: () async {
                       await ConfirmDialog.show(
                         context,
                         hasCancelButton: true,
-                        titleString: '注意',
-                        contentString: '本当にアカウントを削除しますか？',
+                        titleString: '本当にアカウントを削除しますか？',
+                        contentString: 'この操作はもとに戻せません。',
+                        positiveButtonString: '削除',
+                        isDestructiveAction: true,
                         onConfirmed: () async {
                           await ref
                               .read(authControllerProvider)
@@ -42,7 +46,10 @@ class MyPage extends ConsumerWidget {
                         },
                       );
                     },
-                    title: const Text('   アカウントを削除'),
+                    title: const Text(
+                      'アカウントを削除',
+                      style: TextStyle(color: Themes.errorAlertColor),
+                    ),
                   ),
                   const Divider(
                     thickness: 1,


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->

## 対応したこと
- エラー・アラート・破壊的アクションを示す赤色をThemesに追加
- 共通ダイアログのスタイル修正
　- テキスト・ボタンの色、太さなど調整
　- ActionButtonのテキストを変えられるように
　- 破壊的な(もとに戻せない)アクションかどうかのboolを追加、破壊的なら赤色に
- 「アカウント削除」ボタンを赤色に 

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
(ダイアログ中身のサンプル)
<img width="200px" src="https://github.com/user-attachments/assets/c7bd36e9-f654-49db-b364-d74ff3220f24"><img width="200px" src="https://github.com/user-attachments/assets/59d2f7ba-82cb-413e-aa34-8a1cad794017">
--
(現在の状態)
<img width="300px" src="https://github.com/user-attachments/assets/429e4804-b8da-449f-a74a-33e4267cf4b4"><img width="300px" src="https://github.com/user-attachments/assets/449f74d1-a038-4db6-8a63-327a97e0286d">


## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
