### PR TITLE
fix: ビルド互換性のためにGradle wrapperとbuild.gradleを更新

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.15'
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
- ローカル環境特有の問題対応であり、Issue やタスク管理には紐づけていません。

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- `riverpod_generator`導入に伴う、@Itukingだけ発生するlintエラー対応に伴う、`git clone`した時の
`assert localPropertiesFile.exists()`エラー対応。


## 参考資料
- [GitHub Issue: Flutter Unity View Widget](https://github.com/juicycleff/flutter-unity-view-widget/issues/587)
  - `assert localPropertiesFile.exists()` に関するエラー報告。
- [Medium: How to Fix "Could not create task 'generateLockfiles'"](https://medium.com/@roscoe.kerby/how-to-fix-could-not-create-task-generatelockfiles-49c11d952742)
  - Gradle の `generateLockfiles` タスクが作成できない問題に関する解決方法。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [ ] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [ ] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->

- **ドラフト PR** として提出しています。
  - 特に懸念事項はありませんが、有識者の確認後にマージを進めたいと考えています。
  - 確認いただきたいポイント：
    - Gradle Wrapper バージョンアップによる影響がないか。
