### PR TITLE
[TAS-235] マイページのUIリファクタリング&Firebase Authのメールアドレス動的表示対応

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -464,17 +464,17 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
-  cloud_firestore: 7a6d7b8111fe44d13a0e49783daad5219ce798ff
-  cloud_functions: 88050e87b7ff723432a364fab7dadc25e741004c
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
+  cloud_firestore: 63a98b4e73424e1b66ebb6f289eb1a73514cbc49
+  cloud_functions: c5c6d5e971fc5d0693bd30b03255dc21d037dbe0
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Firebase: d80354ed7f6df5f9aca55e9eb47cc4b634735eaf
-  firebase_analytics: d9a47ad8168f1da7bab57cd1400833d2bc48a043
-  firebase_auth: c028e89b64d87f04708ed01f0e7691d997b3fa0d
-  firebase_core: 6cbed78b4f298ed103a9fd034e6dbc846320480f
-  firebase_crashlytics: eb5eb0ef5e6910395adfe177b9ca4a62e8a2f1aa
-  firebase_remote_config: fd021c0d4a6dcf859042b3b74a24cd4d988625c3
-  firebase_storage: f76fa22bb09c7f8f27a80d884e65c7b67541bcbb
+  firebase_analytics: 7ec1166af61987fa968766eb11587c562a5650ee
+  firebase_auth: cecfcb5b0655e1cb66a5c45a88ee77811ca93514
+  firebase_core: 6e223dfa350b2edceb729cea505eaaef59330682
+  firebase_crashlytics: 2a473aeb12dd2d5a3fe150f6ebb8fadc8c9664d7
+  firebase_remote_config: daf651047eff182140a133b4dd3d3b43c59b05da
+  firebase_storage: b57a7b96e6f7ce6a48e7d6cea67c3eabeaedd525
   FirebaseABTesting: 7d6eee42b9137541eac2610e5fea3568d956707a
   FirebaseAnalytics: 4fd42def128146e24e480e89f310e3d8534ea42b
   FirebaseAppCheckInterop: 7bf86d55a2b7e9bd91464120eba3e52e4b63b2e2
@@ -500,37 +500,37 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 672954eac7b141d6954fab9a32d45d6b1d922df8
   FirebaseStorage: 8eede00081a6ce904eaa8d2daa66f1e053e8e6ea
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
-  flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
-  geolocator_apple: 1560c3c875af2a412242c7a923e15d0d401966ff
-  google_sign_in_ios: 19297361f2c51d7d8ac0201b866ef1fa5d1f94a8
+  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
+  flutter_native_splash: df59bb2e1421aa0282cb2e95618af4dcb0c56c29
+  geolocator_apple: 9bcea1918ff7f0062d98345d238ae12718acfbc1
+  google_sign_in_ios: 4111e87aa5e24a4404f00ea13479f35e571969cc
   GoogleAppMeasurement: fc0817122bd4d4189164f85374e06773b9561896
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_gallery_saver_plus: e597bf65a7846979417a3eae0763b71b6dfec6c3
-  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  image_gallery_saver_plus: 782ade975fe6a4600b53e7c1983e3a2979d1e9e5
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  photo_manager: d2fbcc0f2d82458700ee6256a15018210a81d413
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   SDWebImage: 33d0f23bddeb5d209ae959153883247be6703713
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
-  sqlite3_flutter_libs: 3c323550ef3b928bc0aa9513c841e45a7d242832
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  sqlite3_flutter_libs: 069c435986dd4b63461aecd68f4b30be4a9e9daa
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 5262a3fbda5372f57f01e10ae9b57ae4bc981050
 

--- a/lib/features/auth/auth_controller.dart
+++ b/lib/features/auth/auth_controller.dart
@@ -17,6 +17,11 @@ final _authProvider =
 final _userProvider =
     StreamProvider<User?>((ref) => ref.watch(_authProvider).userChanges());
 
+/// [FirebaseAuth]のcurrentUserを取得するProvider
+final firebaseUserProvider = Provider<User?>((ref) {
+  return ref.watch(_authProvider).currentUser;
+});
+
 /// userIdを管理するProvider
 ///
 /// [_userProvider]をwatchしているため、認証状態の変更を検知する

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'widgets/delete_account_button.dart';
+import 'widgets/logout_button.dart';
 
 /// マイページ
 class MyPage extends ConsumerWidget {
@@ -16,22 +17,12 @@ class MyPage extends ConsumerWidget {
       // サインインのリスト部分の設定
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: Column(
+        child: const Column(
           children: [
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.only(top: 160),
-                children: const [
-                  DeleteAccountButton(),
-                  Divider(
-                    thickness: 1,
-                    indent: 20,
-                    endIndent: 20,
-                    color: Colors.white,
-                  ),
-                ],
-              ),
-            ),
+            SizedBox(height: 160),
+            LogoutButton(),
+            SizedBox(height: 20),
+            DeleteAccountButton(),
           ],
         ),
       ),

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'widgets/delete_account_button.dart';
@@ -21,9 +22,9 @@ class MyPage extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             UserInfo(), // ユーザー情報を表示
-            SizedBox(height: 40),
+            Gap(40),
             LogoutButton(), // ログアウトボタン
-            SizedBox(height: 20),
+            Gap(20),
             DeleteAccountButton(), // アカウント削除ボタン
           ],
         ),

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../core/services/analytics_service.dart';
-import '../../core/themes.dart';
-import '../../core/widgets/app_dialog.dart';
-import '../../core/widgets/app_snack_bar.dart';
-import 'auth_controller.dart';
+import 'widgets/delete_account_button.dart';
 
 /// マイページ
 class MyPage extends ConsumerWidget {
@@ -25,35 +21,9 @@ class MyPage extends ConsumerWidget {
             Expanded(
               child: ListView(
                 padding: const EdgeInsets.only(top: 160),
-                children: [
-                  ListTile(
-                    onTap: () async {
-                      await AppDialog.show(
-                        context,
-                        hasCancelButton: true,
-                        titleString: '本当にアカウントを削除しますか？',
-                        contentString: 'この操作はもとに戻せません。',
-                        positiveButtonString: '削除',
-                        isDestructiveAction: true,
-                        onConfirmed: () async {
-                          await ref
-                              .read(authControllerProvider)
-                              .deleteUserAccount();
-                          ref.read(analyticsServiceProvider).sendEvent(
-                                name: 'delete_account',
-                              );
-                          AppSnackBar.show(
-                            message: 'アカウントを削除しました',
-                          );
-                        },
-                      );
-                    },
-                    title: const Text(
-                      'アカウントを削除',
-                      style: TextStyle(color: Themes.errorAlertColor),
-                    ),
-                  ),
-                  const Divider(
+                children: const [
+                  DeleteAccountButton(),
+                  Divider(
                     thickness: 1,
                     indent: 20,
                     endIndent: 20,

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -20,7 +20,7 @@ class MyPage extends ConsumerWidget {
         child: const Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            UserInfo(email: 'mail@example.com'), // ユーザー情報を表示
+            UserInfo(), // ユーザー情報を表示
             SizedBox(height: 40),
             LogoutButton(), // ログアウトボタン
             SizedBox(height: 20),

--- a/lib/features/auth/my_page.dart
+++ b/lib/features/auth/my_page.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'widgets/delete_account_button.dart';
 import 'widgets/logout_button.dart';
+import 'widgets/user_info.dart';
 
 /// マイページ
 class MyPage extends ConsumerWidget {
@@ -14,15 +15,16 @@ class MyPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      // サインインのリスト部分の設定
       body: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: const Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            SizedBox(height: 160),
-            LogoutButton(),
+            UserInfo(email: 'mail@example.com'), // ユーザー情報を表示
+            SizedBox(height: 40),
+            LogoutButton(), // ログアウトボタン
             SizedBox(height: 20),
-            DeleteAccountButton(),
+            DeleteAccountButton(), // アカウント削除ボタン
           ],
         ),
       ),

--- a/lib/features/auth/widgets/delete_account_button.dart
+++ b/lib/features/auth/widgets/delete_account_button.dart
@@ -12,10 +12,9 @@ class DeleteAccountButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Align(
-      alignment: Alignment.topLeft,
+    return Center(
       child: Padding(
-        padding: const EdgeInsets.only(left: 16),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
         child: TextButton(
           onPressed: () async {
             await AppDialog.show(

--- a/lib/features/auth/widgets/delete_account_button.dart
+++ b/lib/features/auth/widgets/delete_account_button.dart
@@ -33,9 +33,12 @@ class DeleteAccountButton extends ConsumerWidget {
               },
             );
           },
-          child: const Text(
+          child: Text(
             'アカウントを削除',
-            style: TextStyle(color: Themes.errorAlertColor, fontSize: 16),
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  fontSize: 18,
+                  color: Themes.errorAlertColor,
+                ),
           ),
         ),
       ),

--- a/lib/features/auth/widgets/delete_account_button.dart
+++ b/lib/features/auth/widgets/delete_account_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../core/services/analytics_service.dart';
+import '../../../core/themes.dart';
+import '../../../core/widgets/app_dialog.dart';
+import '../../../core/widgets/app_snack_bar.dart';
+import '../auth_controller.dart';
+
+class DeleteAccountButton extends ConsumerWidget {
+  const DeleteAccountButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 16),
+        child: TextButton(
+          onPressed: () async {
+            await AppDialog.show(
+              context,
+              hasCancelButton: true,
+              titleString: '本当にアカウントを削除しますか？',
+              contentString: 'この操作はもとに戻せません。',
+              positiveButtonString: '削除',
+              isDestructiveAction: true,
+              onConfirmed: () async {
+                await ref.read(authControllerProvider).deleteUserAccount();
+                ref
+                    .read(analyticsServiceProvider)
+                    .sendEvent(name: 'delete_account');
+                AppSnackBar.show(message: 'アカウントを削除しました');
+              },
+            );
+          },
+          child: const Text(
+            'アカウントを削除',
+            style: TextStyle(color: Themes.errorAlertColor, fontSize: 16),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/widgets/logout_button.dart
+++ b/lib/features/auth/widgets/logout_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../../../core/themes.dart';
+import '../../../core/widgets/app_elevated_button.dart';
 
 class LogoutButton extends StatelessWidget {
   const LogoutButton({super.key});
@@ -8,24 +10,15 @@ class LogoutButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
-      child: ElevatedButton(
+      child: AppElevatedButton(
+        text: 'ログアウト',
         onPressed: () {
           // ログアウト処理を追加
         },
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Themes.mainOrange,
-          foregroundColor: Colors.white,
-          minimumSize: const Size(double.infinity, 50),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(25),
-          ),
-          side: const BorderSide(width: 2),
-          textStyle: Theme.of(context).textTheme.labelLarge?.copyWith(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
-        ),
-        child: const Text('ログアウト'),
+        backgroundColor: Themes.mainOrange,
+        borderColor: Themes.gray.shade900,
+        textColor: Colors.white,
+        height: 50,
       ),
     );
   }

--- a/lib/features/auth/widgets/logout_button.dart
+++ b/lib/features/auth/widgets/logout_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class LogoutButton extends StatelessWidget {
+  const LogoutButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 10),
+      width: double.infinity,
+      height: 50,
+      decoration: BoxDecoration(
+        color: Colors.orange,
+        borderRadius: BorderRadius.circular(25),
+        border: Border.all(width: 2),
+      ),
+      child: TextButton(
+        onPressed: () {
+          // ログアウト処理を追加
+        },
+        child: const Text(
+          'ログアウト',
+          style: TextStyle(
+              color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/widgets/logout_button.dart
+++ b/lib/features/auth/widgets/logout_button.dart
@@ -1,28 +1,31 @@
 import 'package:flutter/material.dart';
+import '../../../core/themes.dart';
 
 class LogoutButton extends StatelessWidget {
   const LogoutButton({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 10),
-      width: double.infinity,
-      height: 50,
-      decoration: BoxDecoration(
-        color: Colors.orange,
-        borderRadius: BorderRadius.circular(25),
-        border: Border.all(width: 2),
-      ),
-      child: TextButton(
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: ElevatedButton(
         onPressed: () {
           // ログアウト処理を追加
         },
-        child: const Text(
-          'ログアウト',
-          style: TextStyle(
-              color: Colors.white, fontSize: 18, fontWeight: FontWeight.bold),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Themes.mainOrange,
+          foregroundColor: Colors.white,
+          minimumSize: const Size(double.infinity, 50),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(25),
+          ),
+          side: const BorderSide(width: 2),
+          textStyle: Theme.of(context).textTheme.labelLarge?.copyWith(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
         ),
+        child: const Text('ログアウト'),
       ),
     );
   }

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class UserInfo extends StatelessWidget {
+  const UserInfo({
+    super.key,
+    required this.email, // メールアドレスを外部から受け取る
+  });
+  final String email;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const CircleAvatar(
+          radius: 40,
+          backgroundColor: Colors.grey,
+          child: Icon(Icons.person, size: 40, color: Colors.white),
+        ),
+        const SizedBox(width: 16),
+        Text(
+          email,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../auth_controller.dart';
@@ -21,14 +22,14 @@ class UserInfo extends ConsumerWidget {
             fontWeight: FontWeight.bold,
           ),
         ),
-        const SizedBox(height: 15),
+        const Gap(15),
         Row(
           children: [
             const CircleAvatar(
               radius: 30,
               backgroundColor: Colors.grey,
             ),
-            const SizedBox(width: 16),
+            const Gap(16),
             Text(
               user?.email ?? '',
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -25,9 +25,8 @@ class UserInfo extends ConsumerWidget {
         Row(
           children: [
             const CircleAvatar(
-              radius: 40,
+              radius: 30,
               backgroundColor: Colors.grey,
-              child: Icon(Icons.person, size: 40, color: Colors.white),
             ),
             const SizedBox(width: 16),
             Text(

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
+import '../../../core/themes.dart';
 import '../auth_controller.dart';
 
 class UserInfo extends ConsumerWidget {
@@ -14,25 +14,26 @@ class UserInfo extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+        Text(
           'ログイン中のアカウント',
-          style: TextStyle(
-            fontSize: 14,
-            color: Colors.grey,
-            fontWeight: FontWeight.bold,
-          ),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Themes.gray.shade600,
+              ),
         ),
         const Gap(15),
         Row(
           children: [
-            const CircleAvatar(
+            CircleAvatar(
               radius: 30,
-              backgroundColor: Colors.grey,
+              backgroundColor: Themes.gray.shade400,
             ),
             const Gap(16),
             Text(
               user?.email ?? '',
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
             ),
           ],
         ),

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -9,17 +9,31 @@ class UserInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const CircleAvatar(
-          radius: 40,
-          backgroundColor: Colors.grey,
-          child: Icon(Icons.person, size: 40, color: Colors.white),
+        const Text(
+          'ログイン中のアカウント',
+          style: TextStyle(
+            fontSize: 14,
+            color: Colors.grey,
+            fontWeight: FontWeight.bold,
+          ),
         ),
-        const SizedBox(width: 16),
-        Text(
-          email,
-          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        const SizedBox(height: 15),
+        Row(
+          children: [
+            const CircleAvatar(
+              radius: 40,
+              backgroundColor: Colors.grey,
+              child: Icon(Icons.person, size: 40, color: Colors.white),
+            ),
+            const SizedBox(width: 16),
+            Text(
+              email,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+
 import '../../../core/themes.dart';
 import '../auth_controller.dart';
 

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,21 +1,14 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../auth_controller.dart';
 
 class UserInfo extends ConsumerWidget {
   const UserInfo({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = FirebaseAuth.instance.currentUser!;
-
-    var email = user.email;
-    for (final providerProfile in user.providerData) {
-      if (providerProfile.email != null) {
-        email = providerProfile.email;
-        break;
-      }
-    }
+    final user = ref.watch(firebaseUserProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -38,7 +31,7 @@ class UserInfo extends ConsumerWidget {
             ),
             const SizedBox(width: 16),
             Text(
-              email!,
+              user?.email ?? '',
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
           ],

--- a/lib/features/auth/widgets/user_info.dart
+++ b/lib/features/auth/widgets/user_info.dart
@@ -1,14 +1,22 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class UserInfo extends StatelessWidget {
-  const UserInfo({
-    super.key,
-    required this.email, // メールアドレスを外部から受け取る
-  });
-  final String email;
+class UserInfo extends ConsumerWidget {
+  const UserInfo({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = FirebaseAuth.instance.currentUser!;
+
+    var email = user.email;
+    for (final providerProfile in user.providerData) {
+      if (providerProfile.email != null) {
+        email = providerProfile.email;
+        break;
+      }
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -30,7 +38,7 @@ class UserInfo extends StatelessWidget {
             ),
             const SizedBox(width: 16),
             Text(
-              email,
+              email!,
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
           ],


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載 -->
https://www.notion.so/masakisato/5c172c1ba84d4828a311350d43642276

## 対応したこと
<!-- 実装の概要を箇条書きする -->
- `firebaseUserProvider` を追加し、`FirebaseAuth` の `currentUser` を管理
- `UserInfo` ウィジェットで `firebaseUserProvider` を使用し、メールアドレスを取得
- `UserInfo` のアイコンを削除し、`CircleAvatar` のサイズを `radius: 40 → 30` に変更
- `MyPage` の UI を整理し、`LogoutButton` と `DeleteAccountButton` を追加
- `ListTile` でのアカウント削除処理を `DeleteAccountButton` に分離
- `LogoutButton` を新規作成し、レイアウトを整理

## 未解決事項
<!-- 別PRで対応するような状況があれば記載 -->
- **ボタンの各余白などを詳細に設定**
- **アイコンおよびログアウト機能の実装およびデザインの決定**
- **アカウント削除がボタンを押した直後に正しく実行されていない**
  - `ref.read(authControllerProvider).deleteUserAccount()` を実行してもアカウントが削除されない
  - `FirebaseAuth`の`delete()`が実行されているか確認が必要

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF -->
<!-- 入力エリアにドラッグ&ドロップしてアップロード -->
<img src="https://github.com/user-attachments/assets/df46ccea-6452-4c9b-8e6e-afe271d860b6" width="300">


## チェックリスト
<!-- 空白を消して`x`をつける -->
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所に GitHub 上でコメントをしたか  

## その他コメント
<!-- 何かあれば！ -->
- `firebaseUserProvider` の配置や責務の分離について、他に適切な方法があればレビューお願いします！
- アカウント削除処理の修正に関しては別タスクで行った方が良いと考えています。
