### PR TITLE
[TAS-253] ログイン画面へリダイレクト処理 / ログイン後の遷移先を修正

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -291,9 +291,9 @@ PODS:
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
   - RecaptchaInterop (100.0.0)
-  - SDWebImage (5.20.1):
-    - SDWebImage/Core (= 5.20.1)
-  - SDWebImage/Core (5.20.1)
+  - SDWebImage (5.20.0):
+    - SDWebImage/Core (= 5.20.0)
+  - SDWebImage/Core (5.20.0)
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
@@ -305,16 +305,16 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.49.1):
-    - sqlite3/common (= 3.49.1)
-  - sqlite3/common (3.49.1)
-  - sqlite3/dbstatvtab (3.49.1):
+  - sqlite3 (3.49.0):
+    - sqlite3/common (= 3.49.0)
+  - sqlite3/common (3.49.0)
+  - sqlite3/dbstatvtab (3.49.0):
     - sqlite3/common
-  - sqlite3/fts5 (3.49.1):
+  - sqlite3/fts5 (3.49.0):
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.49.1):
+  - sqlite3/perf-threadsafe (3.49.0):
     - sqlite3/common
-  - sqlite3/rtree (3.49.1):
+  - sqlite3/rtree (3.49.0):
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
@@ -523,12 +523,12 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  SDWebImage: 33d0f23bddeb5d209ae959153883247be6703713
+  SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  sqlite3: fc1400008a9b3525f5914ed715a5d1af0b8f4983
+  sqlite3: 4922312598b67e1825c6a6c821296dcbf6783046
   sqlite3_flutter_libs: 069c435986dd4b63461aecd68f4b30be4a9e9daa
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -27,10 +27,10 @@ final routerProvider = Provider<GoRouter>(
       if (!isOnboardingCompleted) {
         return OnboardingPage.routePath;
       }
-      final userId = ref.read(userIdProvider);
+      final userId = ref.watch(userIdProvider);
       // ログインしていなければ、サインインページに遷移
-      final isLoggedIn = userId != null;
-      if (!isLoggedIn) {
+      final isSignedIn = userId != null;
+      if (!isSignedIn) {
         return SignInPage.routePath;
       }
 

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -22,7 +22,7 @@ final routerProvider = Provider<GoRouter>(
       final userId = ref.read(userIdProvider);
       // ログインしていなければ、サインインページに遷移
       final isLoggedIn = userId != null;
-      if (isLoggedIn) {
+      if (!isLoggedIn) {
         return SignInPage.routePath;
       }
 

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../features/auth/auth_controller.dart';
 import '../features/auth/my_page.dart';
 import '../features/auth/sign_in_page.dart';
 import '../features/photo/camera/camera_page.dart';
@@ -18,6 +19,14 @@ final routerProvider = Provider<GoRouter>(
     initialLocation: GalleryPage.routePath,
     redirect: (context, state) {
       ref.read(analyticsServiceProvider).sendScreenView(state.matchedLocation);
+      final userId = ref.read(userIdProvider);
+      // ログインしていなければ、サインインページに遷移
+      final isLoggedIn = userId != null;
+      if (isLoggedIn) {
+        return SignInPage.routePath;
+      }
+
+      // TODO(masaki): userId があれば、そのまま遷移 & userId を渡す
       return null;
     },
     routes: [

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -6,6 +6,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../features/auth/auth_controller.dart';
 import '../features/auth/my_page.dart';
 import '../features/auth/sign_in_page.dart';
+import '../features/onboarding/onboarding_controller.dart';
+import '../features/onboarding/onboarding_page.dart';
 import '../features/photo/camera/camera_page.dart';
 import '../features/photo/camera/camera_preview_page.dart';
 import '../features/photo/gallery/gallery_page.dart';
@@ -19,6 +21,12 @@ final routerProvider = Provider<GoRouter>(
     initialLocation: GalleryPage.routePath,
     redirect: (context, state) {
       ref.read(analyticsServiceProvider).sendScreenView(state.matchedLocation);
+      // オンボーディングが終わっていなければ、オンボーディングページに遷移
+      final isOnboardingCompleted =
+          ref.read(isOnboardingCompletedNotifierProvider);
+      if (!isOnboardingCompleted) {
+        return OnboardingPage.routePath;
+      }
       final userId = ref.read(userIdProvider);
       // ログインしていなければ、サインインページに遷移
       final isLoggedIn = userId != null;
@@ -30,6 +38,11 @@ final routerProvider = Provider<GoRouter>(
       return null;
     },
     routes: [
+      GoRoute(
+        name: OnboardingPage.routeName,
+        path: OnboardingPage.routePath,
+        builder: (context, state) => const OnboardingPage(),
+      ),
       GoRoute(
         name: SignInPage.routeName,
         path: SignInPage.routePath,

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -30,14 +30,14 @@ final routerProvider = Provider<GoRouter>(
       return null;
     },
     routes: [
+      GoRoute(
+        name: SignInPage.routeName,
+        path: SignInPage.routePath,
+        builder: (context, state) => const SignInPage(),
+      ),
       ShellRoute(
         builder: (context, state, child) => RootPage(child: child),
         routes: [
-          GoRoute(
-            name: SignInPage.routeName,
-            path: SignInPage.routePath,
-            builder: (context, state) => const SignInPage(),
-          ),
           GoRoute(
             name: GalleryPage.routeName,
             path: GalleryPage.routePath,

--- a/lib/core/services/analytics_service.dart
+++ b/lib/core/services/analytics_service.dart
@@ -39,6 +39,11 @@ class AnalyticsService {
   /// 文字列はスネークケースで記述する。
   final Map<String, String> _parameters;
 
+  /// アプリが開かれたことを送信する。
+  void logAppOpen() {
+    unawaited(_analytics.logAppOpen());
+  }
+
   /// どの画面を開いているか、Analyticsにログを送信するメソッド
   ///
   /// [FirebaseAnalytics.logScreenView]加えて、

--- a/lib/core/widgets/navigation_frame.dart
+++ b/lib/core/widgets/navigation_frame.dart
@@ -7,7 +7,6 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/themes.dart';
-import '../../features/auth/auth_repository.dart';
 import '../../features/auth/my_page.dart';
 import '../../features/onboarding/onboarding_controller.dart';
 import '../../features/photo/gallery/gallery_page.dart';
@@ -39,9 +38,6 @@ class NavigationFrame extends HookConsumerWidget {
     final isClassifyOnboardingCompleted =
         ref.watch(isClassifyOnboardingCompletedNotifierProvider);
 
-    // サインイン状態かどうかに応じて、ボトムナビゲーションバーの表示・非表示を切り替える。
-    final isSignedIn = ref.read(authRepositoryProvider).isSignedIn();
-
     final itemWidth = MediaQuery.of(context).size.width / 3;
     final circleWidth = itemWidth * 0.8;
 
@@ -65,65 +61,63 @@ class NavigationFrame extends HookConsumerWidget {
             topLeft: Radius.circular(16),
             topRight: Radius.circular(16),
           ),
-          child: isSignedIn
-              ? Padding(
-                  padding: const EdgeInsets.only(top: 4, bottom: 16),
-                  child: Stack(
-                    children: [
-                      AnimatedPositioned(
-                        duration: const Duration(milliseconds: 400),
-                        curve: StickyCurve(), // カスタムCurveを使用
-                        left: selectedIndex.value * itemWidth +
-                            (itemWidth - circleWidth) / 2,
-                        child: Container(
-                          width: circleWidth,
-                          height: 72,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(36),
-                            color: Themes.mainOrange,
-                            border: Border.all(
-                              color: Themes.gray.shade900,
-                              width: 2,
-                            ),
-                          ),
-                        ),
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4, bottom: 16),
+            child: Stack(
+              children: [
+                AnimatedPositioned(
+                  duration: const Duration(milliseconds: 400),
+                  curve: StickyCurve(), // カスタムCurveを使用
+                  left: selectedIndex.value * itemWidth +
+                      (itemWidth - circleWidth) / 2,
+                  child: Container(
+                    width: circleWidth,
+                    height: 72,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(36),
+                      color: Themes.mainOrange,
+                      border: Border.all(
+                        color: Themes.gray.shade900,
+                        width: 2,
                       ),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceAround,
-                        children: [
-                          _buildNavItem(
-                            icon: Icons.photo,
-                            label: 'ギャラリー',
-                            index: 0,
-                            context: context,
-                            isClassifyOnboardingCompleted:
-                                isClassifyOnboardingCompleted,
-                            selectedIndex: selectedIndex,
-                          ),
-                          _buildNavItem(
-                            icon: Icons.add,
-                            label: '写真を追加',
-                            index: 1,
-                            context: context,
-                            isClassifyOnboardingCompleted:
-                                isClassifyOnboardingCompleted,
-                            selectedIndex: selectedIndex,
-                          ),
-                          _buildNavItem(
-                            icon: Icons.person,
-                            label: 'マイページ',
-                            index: 2,
-                            context: context,
-                            isClassifyOnboardingCompleted:
-                                isClassifyOnboardingCompleted,
-                            selectedIndex: selectedIndex,
-                          ),
-                        ],
-                      ),
-                    ],
+                    ),
                   ),
-                )
-              : null,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    _buildNavItem(
+                      icon: Icons.photo,
+                      label: 'ギャラリー',
+                      index: 0,
+                      context: context,
+                      isClassifyOnboardingCompleted:
+                          isClassifyOnboardingCompleted,
+                      selectedIndex: selectedIndex,
+                    ),
+                    _buildNavItem(
+                      icon: Icons.add,
+                      label: '写真を追加',
+                      index: 1,
+                      context: context,
+                      isClassifyOnboardingCompleted:
+                          isClassifyOnboardingCompleted,
+                      selectedIndex: selectedIndex,
+                    ),
+                    _buildNavItem(
+                      icon: Icons.person,
+                      label: 'マイページ',
+                      index: 2,
+                      context: context,
+                      isClassifyOnboardingCompleted:
+                          isClassifyOnboardingCompleted,
+                      selectedIndex: selectedIndex,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/auth/auth_controller.dart
+++ b/lib/features/auth/auth_controller.dart
@@ -51,6 +51,11 @@ class AuthController {
     await _authRepository.deleteUserAccount();
   }
 
+  /// ログアウト処理を行う。
+  Future<void> signOut() async {
+    await _authRepository.signOut();
+  }
+
   /// Googleサインイン用メソッド
   Future<({String accessToken, String userId})> signInWithGoogle() {
     return _authRepository.signInWithGoogle();

--- a/lib/features/auth/auth_repository.dart
+++ b/lib/features/auth/auth_repository.dart
@@ -153,11 +153,16 @@ class AuthRepository {
           'userId': userId,
         },
       );
-      // 認証情報をリセットするためにサインアウト
-      await _auth.signOut();
+      // 認証情報をリセットするためにサインアウトする
+      await signOut();
     } on Exception catch (error) {
       logger.e(error.toString());
     }
+  }
+
+  /// サインアウト処理を行う。
+  Future<void> signOut() async {
+    await _auth.signOut();
   }
 
   /// CloudFunctionsのCallable関数を呼び出す

--- a/lib/features/auth/auth_repository.dart
+++ b/lib/features/auth/auth_repository.dart
@@ -47,10 +47,6 @@ class AuthRepository {
   FirebaseAuth get auth => _auth;
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  bool isSignedIn() {
-    return _auth.currentUser != null;
-  }
-
   // Googleサインインのメソッド
   Future<({String accessToken, String userId})> signInWithGoogle() async {
     final googleUser = await GoogleSignIn(

--- a/lib/features/auth/auth_repository.dart
+++ b/lib/features/auth/auth_repository.dart
@@ -157,6 +157,8 @@ class AuthRepository {
           'userId': userId,
         },
       );
+      // 認証情報をリセットするためにサインアウト
+      await _auth.signOut();
     } on Exception catch (error) {
       logger.e(error.toString());
     }

--- a/lib/features/auth/sign_in_page.dart
+++ b/lib/features/auth/sign_in_page.dart
@@ -1,3 +1,4 @@
+import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
@@ -20,9 +21,6 @@ class SignInPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // State Hookを使用して、UIがリビルドされても状態を保持する
-    final isLoading = useState(false);
-
     return Scaffold(
       body: ColoredBox(
         color: Themes.mainOrange,
@@ -40,7 +38,6 @@ class SignInPage extends HookConsumerWidget {
             const Spacer(),
             // Googleで続けるボタン
             _buildSignInButton(
-              isLoading: isLoading,
               context: context,
               ref: ref,
               label: 'Googleで続ける',
@@ -52,7 +49,6 @@ class SignInPage extends HookConsumerWidget {
             const Gap(20),
             // Appleで続けるボタン
             _buildSignInButton(
-              isLoading: isLoading,
               context: context,
               ref: ref,
               label: 'Appleで続ける',
@@ -68,9 +64,9 @@ class SignInPage extends HookConsumerWidget {
     );
   }
 
+  // TODO(masaki): AppElevatedButton との共通化 or プライベートクラス化
   /// サインインボタンの共通化メソッド
   Widget _buildSignInButton({
-    required ValueNotifier<bool> isLoading,
     required BuildContext context,
     required WidgetRef ref,
     required String label,
@@ -79,12 +75,15 @@ class SignInPage extends HookConsumerWidget {
     required Color foregroundColor,
     required Future<void> Function() signInMethod,
   }) {
+    // 多重を実行防止するためのキャッシュ
+    final asyncCache = useState(AsyncCache<dynamic>.ephemeral());
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: ElevatedButton.icon(
-        onPressed: isLoading.value
-            ? () {}
-            : () => _handleSignIn(isLoading, signInMethod, context, ref),
+        onPressed: () {
+          asyncCache.value
+              .fetch(() => _handleSignIn(signInMethod, context, ref));
+        },
         icon: Image.asset(
           iconPath,
           width: 24,
@@ -104,13 +103,11 @@ class SignInPage extends HookConsumerWidget {
 
   /// サインイン処理の共通化
   Future<void> _handleSignIn(
-    ValueNotifier<bool> isLoading,
     Future<void> Function() signIn,
     BuildContext context,
     WidgetRef ref,
   ) async {
     try {
-      isLoading.value = true;
       await signIn();
       if (!context.mounted) {
         return;
@@ -119,8 +116,6 @@ class SignInPage extends HookConsumerWidget {
       context.go(GalleryPage.routePath);
     } on Exception catch (e) {
       AppSnackBar.show(message: 'サインインに失敗しました: $e');
-    } finally {
-      isLoading.value = false;
     }
   }
 }

--- a/lib/features/auth/sign_in_page.dart
+++ b/lib/features/auth/sign_in_page.dart
@@ -8,7 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 // import '../../core/analytics/analytics_service.dart';
 import '../../core/themes.dart';
 import '../../core/widgets/app_snack_bar.dart';
-import '../photo/swipe_photo/swipe_photo_page.dart';
+import '../photo/gallery/gallery_page.dart';
 import 'auth_controller.dart';
 
 /// サインインページ
@@ -115,7 +115,8 @@ class SignInPage extends HookConsumerWidget {
       if (!context.mounted) {
         return;
       }
-      GoRouter.of(context).go(SwipePhotoPage.routePath);
+      // TODO(masaki): 遷移先として、写真選択画面 or ギャラリーページ（空の場合に写真選択画面へ促す）を相談
+      context.go(GalleryPage.routePath);
     } on Exception catch (e) {
       AppSnackBar.show(message: 'サインインに失敗しました: $e');
     } finally {

--- a/lib/features/auth/widgets/delete_account_button.dart
+++ b/lib/features/auth/widgets/delete_account_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../core/services/analytics_service.dart';
@@ -7,7 +6,6 @@ import '../../../core/themes.dart';
 import '../../../core/widgets/app_dialog.dart';
 import '../../../core/widgets/app_snack_bar.dart';
 import '../auth_controller.dart';
-import '../sign_in_page.dart';
 
 class DeleteAccountButton extends ConsumerWidget {
   const DeleteAccountButton({super.key});
@@ -27,14 +25,11 @@ class DeleteAccountButton extends ConsumerWidget {
               positiveButtonString: '削除',
               isDestructiveAction: true,
               onConfirmed: () async {
+                // アカウントが削除された後、ログイン画面へリダイレクトされる
                 await ref.read(authControllerProvider).deleteUserAccount();
                 ref
                     .read(analyticsServiceProvider)
                     .sendEvent(name: 'delete_account');
-                if (!context.mounted) {
-                  return;
-                }
-                context.go(SignInPage.routePath);
                 AppSnackBar.show(message: 'アカウントを削除しました');
               },
             );

--- a/lib/features/auth/widgets/delete_account_button.dart
+++ b/lib/features/auth/widgets/delete_account_button.dart
@@ -25,11 +25,11 @@ class DeleteAccountButton extends ConsumerWidget {
               positiveButtonString: '削除',
               isDestructiveAction: true,
               onConfirmed: () async {
-                // アカウントが削除された後、ログイン画面へリダイレクトされる
-                await ref.read(authControllerProvider).deleteUserAccount();
                 ref
                     .read(analyticsServiceProvider)
                     .sendEvent(name: 'delete_account');
+                // アカウントが削除された後、ログイン画面へリダイレクトされる
+                await ref.read(authControllerProvider).deleteUserAccount();
                 AppSnackBar.show(message: 'アカウントを削除しました');
               },
             );

--- a/lib/features/auth/widgets/logout_button.dart
+++ b/lib/features/auth/widgets/logout_button.dart
@@ -1,19 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../core/services/analytics_service.dart';
 import '../../../core/themes.dart';
 import '../../../core/widgets/app_elevated_button.dart';
+import '../auth_controller.dart';
 
-class LogoutButton extends StatelessWidget {
+class LogoutButton extends ConsumerWidget {
   const LogoutButton({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 10),
       child: AppElevatedButton(
         text: 'ログアウト',
-        onPressed: () {
-          // ログアウト処理を追加
+        onPressed: () async {
+          // ログアウト処理を行い、ログイン画面へリダイレクトされる
+          await ref.read(authControllerProvider).signOut();
+          ref.read(analyticsServiceProvider).sendEvent(name: 'sign_out');
         },
         backgroundColor: Themes.mainOrange,
         borderColor: Themes.gray.shade900,

--- a/lib/features/auth/widgets/logout_button.dart
+++ b/lib/features/auth/widgets/logout_button.dart
@@ -16,9 +16,9 @@ class LogoutButton extends ConsumerWidget {
       child: AppElevatedButton(
         text: 'ログアウト',
         onPressed: () async {
+          ref.read(analyticsServiceProvider).sendEvent(name: 'sign_out');
           // ログアウト処理を行い、ログイン画面へリダイレクトされる
           await ref.read(authControllerProvider).signOut();
-          ref.read(analyticsServiceProvider).sendEvent(name: 'sign_out');
         },
         backgroundColor: Themes.mainOrange,
         borderColor: Themes.gray.shade900,

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -118,10 +118,9 @@ class OnboardingPage extends HookConsumerWidget {
                               curve: Curves.easeInOut,
                             );
                           } else {
-                            // TODO(kim): アナリティクスマージ後にコメントアウトを解除
-                            // ref
-                            //     .read(analyticsServiceProvider)
-                            //     .sendEvent(name: 'complete_onboarding');
+                            ref
+                                .read(analyticsServiceProvider)
+                                .sendEvent(name: 'complete_onboarding');
                             await ref
                                 .read(
                                   isOnboardingCompletedNotifierProvider

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -15,6 +15,9 @@ import 'onboarding_controller.dart';
 class OnboardingPage extends HookConsumerWidget {
   const OnboardingPage({super.key});
 
+  static const routeName = 'onboarding_page';
+  static const routePath = '/onboarding_page';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pageController = usePageController();

--- a/lib/features/root_page.dart
+++ b/lib/features/root_page.dart
@@ -11,6 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../core/repositories/shared_preferences_repository.dart';
 import '../core/widgets/app_dialog.dart';
 import '../core/widgets/navigation_frame.dart';
+import 'auth/auth_controller.dart';
 import 'auth/auth_repository.dart';
 import 'auth/sign_in_page.dart';
 import 'onboarding/onboarding_controller.dart';
@@ -20,13 +21,21 @@ import 'onboarding/onboarding_page.dart';
 ///
 /// 初期化処理が終わり次第、[NavigationFrame]を描画する。
 class RootPage extends HookConsumerWidget {
-  const RootPage({super.key, required this.child});
+  const RootPage({
+    super.key,
+    required this.child,
+    // required this.userId,
+  });
 
   final Widget child;
+
+  // final String userId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isLoading = useState(true);
+    // リダイレクト処理にて userId があることは確認済み
+    final userId = ref.watch(userIdProvider)!;
 
     // 初期化処理を行う非同期関数
     Future<void> init(WidgetRef ref, BuildContext context) async {
@@ -57,6 +66,7 @@ class RootPage extends HookConsumerWidget {
     return isLoading.value
         ? const SizedBox.shrink() // ローディング中は空のウィジェットを表示
         : NavigationFrame(
+            userId: userId,
             child: Stack(
               children: [
                 child,

--- a/lib/features/root_page.dart
+++ b/lib/features/root_page.dart
@@ -8,7 +8,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../core/repositories/shared_preferences_repository.dart';
 import '../core/widgets/app_dialog.dart';
 import '../core/widgets/navigation_frame.dart';
 import 'auth/auth_repository.dart';
@@ -40,9 +39,9 @@ class RootPage extends HookConsumerWidget {
     Future<void> init(WidgetRef ref, BuildContext context) async {
       await Future.wait([
         _checkBuildNumber(context),
-        ref.watch(sharedPreferencesRepositoryProvider).init(),
       ]);
 
+      // TODO(masaki): 削除
       final isSignedIn = ref.read(authRepositoryProvider).isSignedIn();
       if (!isSignedIn && context.mounted) {
         GoRouter.of(context).go(SignInPage.routePath);

--- a/lib/features/root_page.dart
+++ b/lib/features/root_page.dart
@@ -66,7 +66,8 @@ class RootPage extends HookConsumerWidget {
     return isLoading.value
         ? const SizedBox.shrink() // ローディング中は空のウィジェットを表示
         : NavigationFrame(
-            userId: userId,
+            // TODO(masaki): userIdを渡す
+            // userId: userId,
             child: Stack(
               children: [
                 child,

--- a/lib/features/root_page.dart
+++ b/lib/features/root_page.dart
@@ -3,15 +3,12 @@ import 'dart:io';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../core/widgets/app_dialog.dart';
 import '../core/widgets/navigation_frame.dart';
-import 'auth/auth_repository.dart';
-import 'auth/sign_in_page.dart';
 import 'onboarding/onboarding_controller.dart';
 import 'onboarding/onboarding_page.dart';
 
@@ -40,12 +37,6 @@ class RootPage extends HookConsumerWidget {
       await Future.wait([
         _checkBuildNumber(context),
       ]);
-
-      // TODO(masaki): 削除
-      final isSignedIn = ref.read(authRepositoryProvider).isSignedIn();
-      if (!isSignedIn && context.mounted) {
-        GoRouter.of(context).go(SignInPage.routePath);
-      }
     }
 
     // フックの`useEffect`で初期化処理を行う

--- a/lib/features/root_page.dart
+++ b/lib/features/root_page.dart
@@ -11,7 +11,6 @@ import 'package:url_launcher/url_launcher.dart';
 import '../core/repositories/shared_preferences_repository.dart';
 import '../core/widgets/app_dialog.dart';
 import '../core/widgets/navigation_frame.dart';
-import 'auth/auth_controller.dart';
 import 'auth/auth_repository.dart';
 import 'auth/sign_in_page.dart';
 import 'onboarding/onboarding_controller.dart';
@@ -35,7 +34,7 @@ class RootPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isLoading = useState(true);
     // リダイレクト処理にて userId があることは確認済み
-    final userId = ref.watch(userIdProvider)!;
+    // final userId = ref.watch(userIdProvider)!;
 
     // 初期化処理を行う非同期関数
     Future<void> init(WidgetRef ref, BuildContext context) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +9,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'core/repositories/shared_preferences_repository.dart';
 import 'core/router.dart';
+import 'core/services/analytics_service.dart';
 import 'core/themes.dart';
 
 final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
@@ -29,12 +29,7 @@ Future<void> main() async {
     container.read(sharedPreferencesRepositoryProvider).init(),
   ]);
 
-  // TODO(masaki): 修正
-  // Firebase Analyticsのインスタンスを初期化する
-  final analytics = FirebaseAnalytics.instance;
-
-  // アプリが開かれたことを記録する
-  await analytics.logAppOpen();
+  container.read(analyticsServiceProvider).logAppOpen();
 
   FlutterError.onError = (errorDetails) {
     FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,15 +8,16 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import 'core/repositories/shared_preferences_repository.dart';
 import 'core/router.dart';
 import 'core/themes.dart';
 
-final scaffoldMessengerKey =
-    GlobalKey<ScaffoldMessengerState>();
+final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  final container = ProviderContainer();
   await Future.wait([
     Firebase.initializeApp(),
     dotenv.load(),
@@ -25,8 +26,10 @@ Future<void> main() async {
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]),
+    container.read(sharedPreferencesRepositoryProvider).init(),
   ]);
 
+  // TODO(masaki): 修正
   // Firebase Analyticsのインスタンスを初期化する
   final analytics = FirebaseAnalytics.instance;
 
@@ -44,7 +47,10 @@ Future<void> main() async {
     return true;
   };
 
-  runApp(const ProviderScope(child: MyApp()));
+  runApp(UncontrolledProviderScope(
+    container: container,
+    child: const MyApp(),
+  ));
 }
 
 class MyApp extends ConsumerWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
     source: hosted
     version: "2.6.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   appinio_swiper: ^2.1.1
+  async: ^2.12.0
   cached_network_image: ^3.4.0
   camera: ^0.10.6
   cloud_firestore: ^5.2.1


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- リダイレクト時にログインしていなければ常にログイン画面へ遷移するように変更
- ログインページからの遷移先をスワイプ画面からギャラリー画面へ修正
- ログアウト処理

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- 別途、各ページへ userId を渡すようにする

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

アプリ初回起動時：

![CleanShot 2025-03-02 at 18 06 00](https://github.com/user-attachments/assets/33fbbe33-4655-41c5-9a49-0611f2c08bad)


ログアウト時：
![CleanShot 2025-03-02 at 18 07 54](https://github.com/user-attachments/assets/2ec70879-0285-41dd-876b-8bd47fd665ac)

アカウント削除時：

![CleanShot 2025-03-02 at 18 07 54](https://github.com/user-attachments/assets/3010bf5a-19bd-44cc-8867-1a7ce7612178)

## チェックリスト


<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
